### PR TITLE
Add xUnit tests for BpmnParser

### DIFF
--- a/BpmnParser.Tests/BpmnParser.Tests.csproj
+++ b/BpmnParser.Tests/BpmnParser.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BpmnParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/BpmnParser.Tests/ParserTests.cs
+++ b/BpmnParser.Tests/ParserTests.cs
@@ -1,0 +1,47 @@
+using System.Xml;
+using Xunit;
+
+namespace BpmnParser.Tests
+{
+    public class ParserTests
+    {
+        private const string SampleXml = """
+<definitions xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\">
+  <process id=\"p1\">
+    <laneSet>
+      <lane id=\"lane1\" name=\"Lane 1\">
+        <flowNodeRef>task1</flowNodeRef>
+      </lane>
+    </laneSet>
+    <userTask id=\"task1\" name=\"Task 1\" />
+    <serviceTask id=\"task2\" name=\"Task 2\" />
+    <sequenceFlow id=\"flow1\" sourceRef=\"task1\" targetRef=\"task2\" />
+  </process>
+</definitions>
+""";
+
+        [Fact]
+        public void Parse_ReturnsModelWithLanesTasksAndFlows()
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(SampleXml);
+            var parser = new BpmnParser(doc);
+
+            var model = parser.Parse();
+
+            Assert.Single(model.Lanes);
+            var lane = model.Lanes[0];
+            Assert.Equal("Lane 1", lane.Name);
+            Assert.Single(lane.Tasks);
+            var task = lane.Tasks[0];
+            Assert.Equal("task1", task.Id);
+            Assert.Equal("Task 1", task.Name);
+            Assert.Equal("userTask", task.Type);
+
+            Assert.Single(model.Flows);
+            var flow = model.Flows[0];
+            Assert.Equal("task1", flow.SourceId);
+            Assert.Equal("task2", flow.TargetId);
+        }
+    }
+}

--- a/BpmnParser.sln
+++ b/BpmnParser.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.14.36221.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BpmnParser", "BpmnParser.csproj", "{035F6129-981C-499D-BC39-DAEF587BC428}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BpmnParser.Tests", "BpmnParser.Tests/BpmnParser.Tests.csproj", "{98AD47D3-14BF-42EB-AE85-2DB544C34807}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{035F6129-981C-499D-BC39-DAEF587BC428}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{035F6129-981C-499D-BC39-DAEF587BC428}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{035F6129-981C-499D-BC39-DAEF587BC428}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{035F6129-981C-499D-BC39-DAEF587BC428}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {035F6129-981C-499D-BC39-DAEF587BC428}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {035F6129-981C-499D-BC39-DAEF587BC428}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {035F6129-981C-499D-BC39-DAEF587BC428}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {035F6129-981C-499D-BC39-DAEF587BC428}.Release|Any CPU.Build.0 = Release|Any CPU
+                {98AD47D3-14BF-42EB-AE85-2DB544C34807}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {98AD47D3-14BF-42EB-AE85-2DB544C34807}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {98AD47D3-14BF-42EB-AE85-2DB544C34807}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {98AD47D3-14BF-42EB-AE85-2DB544C34807}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add an xUnit test project
- test parser on a small BPMN snippet
- register the test project in the solution

## Testing
- `dotnet test BpmnParser.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da2989fb0832c952fdf7f7f896ac3